### PR TITLE
Fix: scrollController.jump(0) throws exceptions

### DIFF
--- a/lib/search_bar/widget_search.dart
+++ b/lib/search_bar/widget_search.dart
@@ -397,7 +397,9 @@ class _WidgetSearchState extends State<WidgetSearch> with WidgetsBindingObserver
                               hasFirstSearchHappened = true;
                               searchText = value;
                               selectedIndex = 0;
-                              scrollController.jumpTo(0);
+                              if (scrollController.hasClients) {
+                                scrollController.jumpTo(0);
+                              }
                               if (searchText.isEmpty) {
                                 searchResults = previouslyUsedEmojis.toList();
                                 _gridUpdate.value = !_gridUpdate.value;


### PR DESCRIPTION
Checking if scrollController has clients, fixing an exception thrown if it doesn't